### PR TITLE
Compatibility with higher versions of torch-geometric

### DIFF
--- a/deepgate/arch/tfmlp.py
+++ b/deepgate/arch/tfmlp.py
@@ -34,7 +34,7 @@ class TFMlpAggr(MessagePassing):
 
         return self.propagate(edge_index, x=x, edge_attr=edge_attr)
 
-    def message(self, x_i, x_j, edge_attr, index: Tensor, ptr: OptTensor, size_i: Optional[int]):
+    def message(self, x_i, x_j, edge_attr: Optional[Tensor], index: Tensor, ptr: OptTensor, size_i: Optional[int]):
         # h_i: query, h_j: key 
         h_attn_q_i = self.msg_q(x_i)
         h_attn = self.msg_k(x_j)


### PR DESCRIPTION
Higher versions of torch-geometric introduce an optimization which involves strict type checking. Unused `edge_attr` will be treated as None type, leading to assertion failures.